### PR TITLE
fix(ci): include Python patch version in venv cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: venv-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
-          restore-keys: |
-            venv-${{ matrix.os }}-${{ matrix.python-version }}-
+          key: ${{ runner.os }}-venv-${{ steps.py.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Update the GitHub Actions cache key to include the resolved Python patch version from setup-python, preventing reuse of virtualenvs created with a different interpreter path on Windows.