### PR TITLE
refactor(llm): rename token to api_key to match OpenAI terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ cd teledigest
 These are required for the Telegram client that fetches channel
 messages.
 
-## Obtaining an OpenAI Token
+## Obtaining an OpenAI API Key
 
 1. Visit <https://platform.openai.com/api-keys>
 2. Create a new API key
-3. Copy the token - you will need it for the
+3. Copy the api key - you will need it for the
    configuration file
 
 ## Preparing the TOML configuration

--- a/src/teledigest/config.py
+++ b/src/teledigest/config.py
@@ -29,7 +29,7 @@ _DEFAULT_USER_PROMPT = (
 @dataclass
 class LLMConfig:
     model: str
-    token: str
+    api_key: str
     system_prompt: str
     user_prompt: str
 
@@ -164,14 +164,14 @@ def _parse_app_config(raw: Dict[str, Any]) -> AppConfig:
     llm_raw = raw.get("llm") or {}
     prompts_raw = llm_raw.get("prompts") or {}
     llm = LLMConfig(
-        token=str(llm_raw.get("token", "")),
+        api_key=str(llm_raw.get("api_key", "")),
         model=str(llm_raw.get("model", "gpt-5.1")),
         system_prompt=str(prompts_raw.get("system", _DEFAULT_SYSTEM_PROMPT)),
         user_prompt=str(prompts_raw.get("user", _DEFAULT_USER_PROMPT)),
     )
 
-    if not llm.token:
-        raise ValueError("Config [llm].token is required.")
+    if not llm.api_key:
+        raise ValueError("Config [llm].api_key is required.")
 
     # --- logging ---
     logging_raw = raw.get("logging") or {}

--- a/src/teledigest/llm.py
+++ b/src/teledigest/llm.py
@@ -67,7 +67,7 @@ def strip_markdown_fence(text: str) -> str:
 
 
 def llm_summarize(day: dt.date, messages) -> str:
-    client = OpenAI(api_key=get_config().llm.token)
+    client = OpenAI(api_key=get_config().llm.api_key)
 
     system, user = build_prompt(day, messages)
     log.info("Calling OpenAI for summary (%d messages)...", len(messages))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,7 +25,7 @@ def _make_minimal_raw() -> Dict[str, Any]:
             "time_zone": "Europe/Warsaw",
         },
         "llm": {
-            "token": "sk-test",
+            "api_key": "sk-test",
             # intentionally omit "model" to test default
             # prompts will be omitted in some tests to use defaults
         },
@@ -51,14 +51,14 @@ def test_load_toml_success(tmp_path: Path) -> None:
         summary_target = "@digest"
 
         [llm]
-        token = "sk-test"
+        api_key = "sk-test"
         """
     )
 
     data = config._load_toml(cfg_path)
     assert data["telegram"]["api_id"] == 1
     assert data["bot"]["channels"] == ["@ch"]
-    assert data["llm"]["token"] == "sk-test"
+    assert data["llm"]["api_key"] == "sk-test"
 
 
 def test_load_toml_missing_file_raises() -> None:
@@ -95,7 +95,7 @@ def test_parse_app_config_valid_minimal_defaults() -> None:
     assert app_cfg.storage.rag_keywords == []
 
     # llm
-    assert app_cfg.llm.token == "sk-test"
+    assert app_cfg.llm.api_key == "sk-test"
     # model default from config._DEFAULT_* if not provided
     assert app_cfg.llm.model == "gpt-5.1"
     # prompts default to builtin prompts if [llm.prompts] missing
@@ -181,14 +181,14 @@ def test_parse_app_config_bot_summary_target_required() -> None:
     assert "Config [bot].summary_target is required." in str(exc.value)
 
 
-def test_parse_app_config_llm_token_required() -> None:
+def test_parse_app_config_llm_api_key_required() -> None:
     raw = _make_minimal_raw()
-    raw["llm"]["token"] = ""
+    raw["llm"]["api_key"] = ""
 
     with pytest.raises(ValueError) as exc:
         config._parse_app_config(raw)
 
-    assert "Config [llm].token is required." in str(exc.value)
+    assert "Config [llm].api_key is required." in str(exc.value)
 
 
 # ---------------------------------------------------------------------------
@@ -251,7 +251,7 @@ def test_init_config_and_get_config_roundtrip(
         time_zone = "Europe/Warsaw"
 
         [llm]
-        token = "sk-42"
+        api_key = "sk-42"
 
         [storage]
         db_path = "messages_fts.db"
@@ -273,7 +273,7 @@ def test_init_config_and_get_config_roundtrip(
     # basic sanity checks
     assert app_cfg.telegram.api_id == 42
     assert app_cfg.bot.channels == ["@c1", "@c2"]
-    assert app_cfg.llm.token == "sk-42"
+    assert app_cfg.llm.api_key == "sk-42"
     assert app_cfg.storage.rag_keywords == ["k1", "k2"]
     assert app_cfg.logging.level == "DEBUG"
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -23,7 +23,7 @@ def _make_app_config(
     bot = cfg.BotConfig(channels=["@c1"], summary_target="@digest")
     llm = cfg.LLMConfig(
         model="gpt-4.1",
-        token="sk-test",
+        api_key="sk-test",
         system_prompt="",
         user_prompt="",
     )


### PR DESCRIPTION
- Rename LLM configuration field from `token` to `api_key`
- Align configuration naming with official OpenAI documentation
- Update README to consistently refer to "OpenAI API key"
- Adjust config parsing, validation, and error messages accordingly