### PR TITLE
chore(release): Initial 0.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "teledigest"
-version = "0.0.1"
+version = "0.1.0"
 description = "LLM-driven Telegram digest bot"
 authors = [{ name = "Igor Opaniuk", email = "igor.opaniuk@gmail.com" }]
 license = "MIT"


### PR DESCRIPTION
Initial release of Teledigest.

This release establishes the first stable version of the project and serves as the baseline for future development and releases.