### PR TITLE
ci: add conventional commit message check for pull requests

### DIFF
--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -1,0 +1,15 @@
+name: Conventional Commits
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: webiny/action-conventional-commits@v1.3.0
+        with:
+          allowed-commit-types: "feat,fix,docs,build,chore,refactor,test,ci"
+


### PR DESCRIPTION
Enforce Conventional Commits on pull requests to ensure consistent and machine-readable commit history.

Allowed commit types:
feat, fix, docs, build, chore, refactor, test