### PR TITLE
fix(auth): support alphanumeric and hyphenated login codes

### DIFF
--- a/src/teledigest/telegram_client.py
+++ b/src/teledigest/telegram_client.py
@@ -207,7 +207,7 @@ async def auth_dialog_handler(event):
         try:
             await user_client.sign_in(
                 phone=dialog.phone,
-                code="".join(ch for ch in text if ch.isdigit()),
+                code="".join(ch for ch in text if ch.isalnum() or ch == "-"),
                 phone_code_hash=dialog.phone_code_hash,
             )
 


### PR DESCRIPTION
Allow authentication codes (`/auth` command) containing letters and hyphens (e.g. `sSNG-Wssf0k`) instead of digits-only codes.

Fixes: `2006f1815c ("feat(auth): add bot-based /auth flow for user client")`