### PR TITLE
Bugfix/address misc issues

### DIFF
--- a/src/teledigest/config.py
+++ b/src/teledigest/config.py
@@ -182,7 +182,13 @@ def _parse_app_config(raw: Dict[str, Any]) -> AppConfig:
 
     # --- logging ---
     logging_raw = raw.get("logging") or {}
-    logging_cfg = LoggingConfig(level=str(logging_raw.get("level", "INFO")))
+    logging_level = str(logging_raw.get("level", "INFO"))
+    if not isinstance(getattr(logging, logging_level.upper(), None), int):
+        raise ValueError(
+            f"Config [logging].level is invalid: {logging_level!r}. "
+            "Valid values are: DEBUG, INFO, WARNING, ERROR, CRITICAL."
+        )
+    logging_cfg = LoggingConfig(level=logging_level)
 
     return AppConfig(
         telegram=telegram,
@@ -231,7 +237,7 @@ def _configure_logging(logging_cfg: LoggingConfig) -> None:
     """
     Basic logging setup based on config.
     """
-    level = getattr(logging, logging_cfg.level.upper(), logging.INFO)
+    level = getattr(logging, logging_cfg.level.upper())
     logging.basicConfig(
         level=level,
         format="%(asctime)s [%(levelname)s] %(name)s - %(message)s",

--- a/src/teledigest/config.py
+++ b/src/teledigest/config.py
@@ -199,6 +199,12 @@ def init_config(
 
     global _CONFIG
     if _CONFIG is not None:
+        if explicit_path is not None:
+            log.warning(
+                "init_config() called again with explicit_path=%s, "
+                "but config is already loaded; the new path will be ignored.",
+                explicit_path,
+            )
         return _CONFIG
 
     config_path = _locate_config_path(explicit_path)

--- a/src/teledigest/llm.py
+++ b/src/teledigest/llm.py
@@ -59,7 +59,8 @@ def llm_summarize(day: dt.date, messages) -> str:
         )
 
         content = response.choices[0].message.content
-        assert content is not None
+        if content is None:
+            raise ValueError("OpenAI returned no content")
         summary = content.strip()
         summary = strip_markdown_fence(summary)
 

--- a/src/teledigest/main.py
+++ b/src/teledigest/main.py
@@ -80,7 +80,7 @@ def main() -> int:
         log.info("Shutting down via KeyboardInterrupt")
         return 130
     except Exception as e:
-        if getattr(args, "debug", False):
+        if args.debug:
             traceback.print_exc()
         else:
             # Keep stderr clean by default (no full backtrace)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -217,6 +217,43 @@ def test_parse_app_config_llm_base_url_empty_str() -> None:
 
 
 # ---------------------------------------------------------------------------
+# _parse_app_config – logging.level validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_level", ["TRACE", "VERBOSE", "ALL", "WARN1", ""])
+def test_parse_app_config_invalid_logging_level_raises(bad_level: str) -> None:
+    raw = _make_minimal_raw()
+    raw["logging"] = {"level": bad_level}
+
+    with pytest.raises(ValueError) as exc:
+        config._parse_app_config(raw)
+
+    assert "[logging].level" in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "good_level", ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+)
+def test_parse_app_config_valid_logging_levels_accepted(good_level: str) -> None:
+    raw = _make_minimal_raw()
+    raw["logging"] = {"level": good_level}
+
+    app_cfg = config._parse_app_config(raw)
+
+    assert app_cfg.logging.level == good_level
+
+
+def test_parse_app_config_logging_level_is_case_insensitive() -> None:
+    raw = _make_minimal_raw()
+    raw["logging"] = {"level": "debug"}
+
+    app_cfg = config._parse_app_config(raw)
+
+    assert app_cfg.logging.level == "debug"
+
+
+# ---------------------------------------------------------------------------
 # _locate_config_path / _default_config_path
 # ---------------------------------------------------------------------------
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -303,6 +303,59 @@ def test_init_config_and_get_config_roundtrip(
     assert app_cfg.logging.level == "DEBUG"
 
 
+def test_init_config_second_call_with_explicit_path_emits_warning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A second init_config() with an explicit path must not silently discard it.
+
+    Callers that pass an explicit path expect it to take effect.  Silently
+    returning the cached config makes misconfigured test setups and multi-
+    process deployments very hard to debug.  The warning makes the "first
+    caller wins" contract visible in logs.
+    """
+    # Provide an already-loaded config instance
+    dummy_cfg = config._parse_app_config(
+        {
+            "telegram": {"api_id": 1, "api_hash": "h", "bot_token": "t"},
+            "bot": {"channels": ["@c"], "summary_target": "@d"},
+            "llm": {"api_key": "sk-x"},
+        }
+    )
+    monkeypatch.setattr(config, "_CONFIG", dummy_cfg, raising=False)
+
+    second_path = tmp_path / "other.toml"
+
+    with caplog.at_level("WARNING", logger="teledigest"):
+        result = config.init_config(explicit_path=second_path)
+
+    # The cached config is still returned
+    assert result is dummy_cfg
+    # The caller is warned that their path was ignored
+    assert any("ignored" in r.message for r in caplog.records)
+    assert any(str(second_path) in r.message for r in caplog.records)
+
+
+def test_init_config_second_call_without_explicit_path_is_silent(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Re-calling init_config() with no path is the normal 'get current config'
+    pattern and must not produce any warnings."""
+    dummy_cfg = config._parse_app_config(
+        {
+            "telegram": {"api_id": 1, "api_hash": "h", "bot_token": "t"},
+            "bot": {"channels": ["@c"], "summary_target": "@d"},
+            "llm": {"api_key": "sk-x"},
+        }
+    )
+    monkeypatch.setattr(config, "_CONFIG", dummy_cfg, raising=False)
+
+    with caplog.at_level("WARNING", logger="teledigest"):
+        result = config.init_config()
+
+    assert result is dummy_cfg
+    assert caplog.records == []
+
+
 def test_get_config_raises_if_not_initialized(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(config, "_CONFIG", None, raising=False)
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -159,6 +159,31 @@ def test_llm_summarize_strips_markdown_fence(app_config):
     assert result == "Summary"
 
 
+def test_llm_summarize_handles_none_content_gracefully(app_config):
+    """API can legally return content=None for tool-call responses.
+
+    The old assert would be silently stripped under python -O, turning a
+    predictable ValueError into an AttributeError on .strip().  The explicit
+    guard must remain effective regardless of the optimisation flag.
+    """
+    messages = [Message(channel="@c1", text="news")]
+    day = dt.date(2024, 1, 1)
+
+    mock_response = MagicMock()
+    mock_response.choices[0].message.content = None
+
+    with patch("teledigest.llm.OpenAI") as mock_openai_cls:
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.chat.completions.create.return_value = mock_response
+
+        result = llm.llm_summarize(day, messages)
+
+    assert "Failed to generate" in result
+    assert "2024-01-01" in result
+    assert "no content" in result.lower()
+
+
 def test_llm_summarize_handles_api_error_gracefully(app_config):
     messages = [Message(channel="@c1", text="news")]
     day = dt.date(2024, 1, 1)


### PR DESCRIPTION
Four cases where the code swallowed errors or misled callers instead of failing clearly:

- `llm.py` — assert content is not None is stripped by python -O, turning a predictable error into an opaque AttributeError. Replaced with an explicit ValueError.
- `main.py` — getattr(args, "debug", False) implied args.debug could be absent, which is never true. Replaced with a direct attribute access.
- `config.py` (init_config) — a second call with a different explicit path was silently ignored. Now emits a WARNING so the "first caller wins" contract is visible in logs.
- `config.py` (_parse_app_config) — invalid log levels (e.g. "TRACE") silently fell back to INFO. Validation now raises ValueError at startup, consistent with all other config field checks