### PR TITLE
test: add full unit-test coverage across teledigest modules

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -153,6 +153,125 @@ files = [
 markers = {main = "platform_system == \"Windows\"", dev = "platform_system == \"Windows\" or sys_platform == \"win32\""}
 
 [[package]]
+name = "coverage"
+version = "7.13.4"
+description = "Code coverage measurement for Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "coverage-7.13.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0fc31c787a84f8cd6027eba44010517020e0d18487064cd3d8968941856d1415"},
+    {file = "coverage-7.13.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a32ebc02a1805adf637fc8dec324b5cdacd2e493515424f70ee33799573d661b"},
+    {file = "coverage-7.13.4-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e24f9156097ff9dc286f2f913df3a7f63c0e333dcafa3c196f2c18b4175ca09a"},
+    {file = "coverage-7.13.4-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8041b6c5bfdc03257666e9881d33b1abc88daccaf73f7b6340fb7946655cd10f"},
+    {file = "coverage-7.13.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a09cfa6a5862bc2fc6ca7c3def5b2926194a56b8ab78ffcf617d28911123012"},
+    {file = "coverage-7.13.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:296f8b0af861d3970c2a4d8c91d48eb4dd4771bcef9baedec6a9b515d7de3def"},
+    {file = "coverage-7.13.4-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e101609bcbbfb04605ea1027b10dc3735c094d12d40826a60f897b98b1c30256"},
+    {file = "coverage-7.13.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:aa3feb8db2e87ff5e6d00d7e1480ae241876286691265657b500886c98f38bda"},
+    {file = "coverage-7.13.4-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:4fc7fa81bbaf5a02801b65346c8b3e657f1d93763e58c0abdf7c992addd81a92"},
+    {file = "coverage-7.13.4-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:33901f604424145c6e9c2398684b92e176c0b12df77d52db81c20abd48c3794c"},
+    {file = "coverage-7.13.4-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:bb28c0f2cf2782508a40cec377935829d5fcc3ad9a3681375af4e84eb34b6b58"},
+    {file = "coverage-7.13.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9d107aff57a83222ddbd8d9ee705ede2af2cc926608b57abed8ef96b50b7e8f9"},
+    {file = "coverage-7.13.4-cp310-cp310-win32.whl", hash = "sha256:a6f94a7d00eb18f1b6d403c91a88fd58cfc92d4b16080dfdb774afc8294469bf"},
+    {file = "coverage-7.13.4-cp310-cp310-win_amd64.whl", hash = "sha256:2cb0f1e000ebc419632bbe04366a8990b6e32c4e0b51543a6484ffe15eaeda95"},
+    {file = "coverage-7.13.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d490ba50c3f35dd7c17953c68f3270e7ccd1c6642e2d2afe2d8e720b98f5a053"},
+    {file = "coverage-7.13.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:19bc3c88078789f8ef36acb014d7241961dbf883fd2533d18cb1e7a5b4e28b11"},
+    {file = "coverage-7.13.4-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3998e5a32e62fdf410c0dbd3115df86297995d6e3429af80b8798aad894ca7aa"},
+    {file = "coverage-7.13.4-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8e264226ec98e01a8e1054314af91ee6cde0eacac4f465cc93b03dbe0bce2fd7"},
+    {file = "coverage-7.13.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a3aa4e7b9e416774b21797365b358a6e827ffadaaca81b69ee02946852449f00"},
+    {file = "coverage-7.13.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:71ca20079dd8f27fcf808817e281e90220475cd75115162218d0e27549f95fef"},
+    {file = "coverage-7.13.4-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e2f25215f1a359ab17320b47bcdaca3e6e6356652e8256f2441e4ef972052903"},
+    {file = "coverage-7.13.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d65b2d373032411e86960604dc4edac91fdfb5dca539461cf2cbe78327d1e64f"},
+    {file = "coverage-7.13.4-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94eb63f9b363180aff17de3e7c8760c3ba94664ea2695c52f10111244d16a299"},
+    {file = "coverage-7.13.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:e856bf6616714c3a9fbc270ab54103f4e685ba236fa98c054e8f87f266c93505"},
+    {file = "coverage-7.13.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:65dfcbe305c3dfe658492df2d85259e0d79ead4177f9ae724b6fb245198f55d6"},
+    {file = "coverage-7.13.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b507778ae8a4c915436ed5c2e05b4a6cecfa70f734e19c22a005152a11c7b6a9"},
+    {file = "coverage-7.13.4-cp311-cp311-win32.whl", hash = "sha256:784fc3cf8be001197b652d51d3fd259b1e2262888693a4636e18879f613a62a9"},
+    {file = "coverage-7.13.4-cp311-cp311-win_amd64.whl", hash = "sha256:2421d591f8ca05b308cf0092807308b2facbefe54af7c02ac22548b88b95c98f"},
+    {file = "coverage-7.13.4-cp311-cp311-win_arm64.whl", hash = "sha256:79e73a76b854d9c6088fe5d8b2ebe745f8681c55f7397c3c0a016192d681045f"},
+    {file = "coverage-7.13.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:02231499b08dabbe2b96612993e5fc34217cdae907a51b906ac7fca8027a4459"},
+    {file = "coverage-7.13.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40aa8808140e55dc022b15d8aa7f651b6b3d68b365ea0398f1441e0b04d859c3"},
+    {file = "coverage-7.13.4-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5b856a8ccf749480024ff3bd7310adaef57bf31fd17e1bfc404b7940b6986634"},
+    {file = "coverage-7.13.4-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2c048ea43875fbf8b45d476ad79f179809c590ec7b79e2035c662e7afa3192e3"},
+    {file = "coverage-7.13.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b7b38448866e83176e28086674fe7368ab8590e4610fb662b44e345b86d63ffa"},
+    {file = "coverage-7.13.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:de6defc1c9badbf8b9e67ae90fd00519186d6ab64e5cc5f3d21359c2a9b2c1d3"},
+    {file = "coverage-7.13.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7eda778067ad7ffccd23ecffce537dface96212576a07924cbf0d8799d2ded5a"},
+    {file = "coverage-7.13.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e87f6c587c3f34356c3759f0420693e35e7eb0e2e41e4c011cb6ec6ecbbf1db7"},
+    {file = "coverage-7.13.4-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:8248977c2e33aecb2ced42fef99f2d319e9904a36e55a8a68b69207fb7e43edc"},
+    {file = "coverage-7.13.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:25381386e80ae727608e662474db537d4df1ecd42379b5ba33c84633a2b36d47"},
+    {file = "coverage-7.13.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ee756f00726693e5ba94d6df2bdfd64d4852d23b09bb0bc700e3b30e6f333985"},
+    {file = "coverage-7.13.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fdfc1e28e7c7cdce44985b3043bc13bbd9c747520f94a4d7164af8260b3d91f0"},
+    {file = "coverage-7.13.4-cp312-cp312-win32.whl", hash = "sha256:01d4cbc3c283a17fc1e42d614a119f7f438eabb593391283adca8dc86eff1246"},
+    {file = "coverage-7.13.4-cp312-cp312-win_amd64.whl", hash = "sha256:9401ebc7ef522f01d01d45532c68c5ac40fb27113019b6b7d8b208f6e9baa126"},
+    {file = "coverage-7.13.4-cp312-cp312-win_arm64.whl", hash = "sha256:b1ec7b6b6e93255f952e27ab58fbc68dcc468844b16ecbee881aeb29b6ab4d8d"},
+    {file = "coverage-7.13.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b66a2da594b6068b48b2692f043f35d4d3693fb639d5ea8b39533c2ad9ac3ab9"},
+    {file = "coverage-7.13.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3599eb3992d814d23b35c536c28df1a882caa950f8f507cef23d1cbf334995ac"},
+    {file = "coverage-7.13.4-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:93550784d9281e374fb5a12bf1324cc8a963fd63b2d2f223503ef0fd4aa339ea"},
+    {file = "coverage-7.13.4-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b720ce6a88a2755f7c697c23268ddc47a571b88052e6b155224347389fdf6a3b"},
+    {file = "coverage-7.13.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7b322db1284a2ed3aa28ffd8ebe3db91c929b7a333c0820abec3d838ef5b3525"},
+    {file = "coverage-7.13.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f4594c67d8a7c89cf922d9df0438c7c7bb022ad506eddb0fdb2863359ff78242"},
+    {file = "coverage-7.13.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:53d133df809c743eb8bce33b24bcababb371f4441340578cd406e084d94a6148"},
+    {file = "coverage-7.13.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:76451d1978b95ba6507a039090ba076105c87cc76fc3efd5d35d72093964d49a"},
+    {file = "coverage-7.13.4-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:7f57b33491e281e962021de110b451ab8a24182589be17e12a22c79047935e23"},
+    {file = "coverage-7.13.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:1731dc33dc276dafc410a885cbf5992f1ff171393e48a21453b78727d090de80"},
+    {file = "coverage-7.13.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:bd60d4fe2f6fa7dff9223ca1bbc9f05d2b6697bc5961072e5d3b952d46e1b1ea"},
+    {file = "coverage-7.13.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9181a3ccead280b828fae232df12b16652702b49d41e99d657f46cc7b1f6ec7a"},
+    {file = "coverage-7.13.4-cp313-cp313-win32.whl", hash = "sha256:f53d492307962561ac7de4cd1de3e363589b000ab69617c6156a16ba7237998d"},
+    {file = "coverage-7.13.4-cp313-cp313-win_amd64.whl", hash = "sha256:e6f70dec1cc557e52df5306d051ef56003f74d56e9c4dd7ddb07e07ef32a84dd"},
+    {file = "coverage-7.13.4-cp313-cp313-win_arm64.whl", hash = "sha256:fb07dc5da7e849e2ad31a5d74e9bece81f30ecf5a42909d0a695f8bd1874d6af"},
+    {file = "coverage-7.13.4-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:40d74da8e6c4b9ac18b15331c4b5ebc35a17069410cad462ad4f40dcd2d50c0d"},
+    {file = "coverage-7.13.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4223b4230a376138939a9173f1bdd6521994f2aff8047fae100d6d94d50c5a12"},
+    {file = "coverage-7.13.4-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1d4be36a5114c499f9f1f9195e95ebf979460dbe2d88e6816ea202010ba1c34b"},
+    {file = "coverage-7.13.4-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:200dea7d1e8095cc6e98cdabe3fd1d21ab17d3cee6dab00cadbb2fe35d9c15b9"},
+    {file = "coverage-7.13.4-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b8eb931ee8e6d8243e253e5ed7336deea6904369d2fd8ae6e43f68abbf167092"},
+    {file = "coverage-7.13.4-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:75eab1ebe4f2f64d9509b984f9314d4aa788540368218b858dad56dc8f3e5eb9"},
+    {file = "coverage-7.13.4-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c35eb28c1d085eb7d8c9b3296567a1bebe03ce72962e932431b9a61f28facf26"},
+    {file = "coverage-7.13.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:eb88b316ec33760714a4720feb2816a3a59180fd58c1985012054fa7aebee4c2"},
+    {file = "coverage-7.13.4-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:7d41eead3cc673cbd38a4417deb7fd0b4ca26954ff7dc6078e33f6ff97bed940"},
+    {file = "coverage-7.13.4-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:fb26a934946a6afe0e326aebe0730cdff393a8bc0bbb65a2f41e30feddca399c"},
+    {file = "coverage-7.13.4-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:dae88bc0fc77edaa65c14be099bd57ee140cf507e6bfdeea7938457ab387efb0"},
+    {file = "coverage-7.13.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:845f352911777a8e722bfce168958214951e07e47e5d5d9744109fa5fe77f79b"},
+    {file = "coverage-7.13.4-cp313-cp313t-win32.whl", hash = "sha256:2fa8d5f8de70688a28240de9e139fa16b153cc3cbb01c5f16d88d6505ebdadf9"},
+    {file = "coverage-7.13.4-cp313-cp313t-win_amd64.whl", hash = "sha256:9351229c8c8407645840edcc277f4a2d44814d1bc34a2128c11c2a031d45a5dd"},
+    {file = "coverage-7.13.4-cp313-cp313t-win_arm64.whl", hash = "sha256:30b8d0512f2dc8c8747557e8fb459d6176a2c9e5731e2b74d311c03b78451997"},
+    {file = "coverage-7.13.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:300deaee342f90696ed186e3a00c71b5b3d27bffe9e827677954f4ee56969601"},
+    {file = "coverage-7.13.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:29e3220258d682b6226a9b0925bc563ed9a1ebcff3cad30f043eceea7eaf2689"},
+    {file = "coverage-7.13.4-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:391ee8f19bef69210978363ca930f7328081c6a0152f1166c91f0b5fdd2a773c"},
+    {file = "coverage-7.13.4-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0dd7ab8278f0d58a0128ba2fca25824321f05d059c1441800e934ff2efa52129"},
+    {file = "coverage-7.13.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78cdf0d578b15148b009ccf18c686aa4f719d887e76e6b40c38ffb61d264a552"},
+    {file = "coverage-7.13.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:48685fee12c2eb3b27c62f2658e7ea21e9c3239cba5a8a242801a0a3f6a8c62a"},
+    {file = "coverage-7.13.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4e83efc079eb39480e6346a15a1bcb3e9b04759c5202d157e1dd4303cd619356"},
+    {file = "coverage-7.13.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ecae9737b72408d6a950f7e525f30aca12d4bd8dd95e37342e5beb3a2a8c4f71"},
+    {file = "coverage-7.13.4-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ae4578f8528569d3cf303fef2ea569c7f4c4059a38c8667ccef15c6e1f118aa5"},
+    {file = "coverage-7.13.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:6fdef321fdfbb30a197efa02d48fcd9981f0d8ad2ae8903ac318adc653f5df98"},
+    {file = "coverage-7.13.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b0f6ccf3dbe577170bebfce1318707d0e8c3650003cb4b3a9dd744575daa8b5"},
+    {file = "coverage-7.13.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:75fcd519f2a5765db3f0e391eb3b7d150cce1a771bf4c9f861aeab86c767a3c0"},
+    {file = "coverage-7.13.4-cp314-cp314-win32.whl", hash = "sha256:8e798c266c378da2bd819b0677df41ab46d78065fb2a399558f3f6cae78b2fbb"},
+    {file = "coverage-7.13.4-cp314-cp314-win_amd64.whl", hash = "sha256:245e37f664d89861cf2329c9afa2c1fe9e6d4e1a09d872c947e70718aeeac505"},
+    {file = "coverage-7.13.4-cp314-cp314-win_arm64.whl", hash = "sha256:ad27098a189e5838900ce4c2a99f2fe42a0bf0c2093c17c69b45a71579e8d4a2"},
+    {file = "coverage-7.13.4-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:85480adfb35ffc32d40918aad81b89c69c9cc5661a9b8a81476d3e645321a056"},
+    {file = "coverage-7.13.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:79be69cf7f3bf9b0deeeb062eab7ac7f36cd4cc4c4dd694bd28921ba4d8596cc"},
+    {file = "coverage-7.13.4-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:caa421e2684e382c5d8973ac55e4f36bed6821a9bad5c953494de960c74595c9"},
+    {file = "coverage-7.13.4-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14375934243ee05f56c45393fe2ce81fe5cc503c07cee2bdf1725fb8bef3ffaf"},
+    {file = "coverage-7.13.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:25a41c3104d08edb094d9db0d905ca54d0cd41c928bb6be3c4c799a54753af55"},
+    {file = "coverage-7.13.4-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f01afcff62bf9a08fb32b2c1d6e924236c0383c02c790732b6537269e466a72"},
+    {file = "coverage-7.13.4-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:eb9078108fbf0bcdde37c3f4779303673c2fa1fe8f7956e68d447d0dd426d38a"},
+    {file = "coverage-7.13.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0e086334e8537ddd17e5f16a344777c1ab8194986ec533711cbe6c41cde841b6"},
+    {file = "coverage-7.13.4-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:725d985c5ab621268b2edb8e50dfe57633dc69bda071abc470fed55a14935fd3"},
+    {file = "coverage-7.13.4-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:3c06f0f1337c667b971ca2f975523347e63ec5e500b9aa5882d91931cd3ef750"},
+    {file = "coverage-7.13.4-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:590c0ed4bf8e85f745e6b805b2e1c457b2e33d5255dd9729743165253bc9ad39"},
+    {file = "coverage-7.13.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:eb30bf180de3f632cd043322dad5751390e5385108b2807368997d1a92a509d0"},
+    {file = "coverage-7.13.4-cp314-cp314t-win32.whl", hash = "sha256:c4240e7eded42d131a2d2c4dec70374b781b043ddc79a9de4d55ca71f8e98aea"},
+    {file = "coverage-7.13.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4c7d3cc01e7350f2f0f6f7036caaf5673fb56b6998889ccfe9e1c1fe75a9c932"},
+    {file = "coverage-7.13.4-cp314-cp314t-win_arm64.whl", hash = "sha256:23e3f687cf945070d1c90f85db66d11e3025665d8dafa831301a0e0038f3db9b"},
+    {file = "coverage-7.13.4-py3-none-any.whl", hash = "sha256:1af1641e57cf7ba1bd67d677c9abdbcd6cc2ab7da3bca7fa1e2b7e50e65f2ad0"},
+    {file = "coverage-7.13.4.tar.gz", hash = "sha256:e5c8f6ed1e61a8b2dcdf31eb0b9bbf0130750ca79c1c49eb898e2ad86f5ccc91"},
+]
+
+[package.extras]
+toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 description = "Distribution utilities"
@@ -957,6 +1076,26 @@ docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1)"]
 testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
 
 [[package]]
+name = "pytest-cov"
+version = "7.0.0"
+description = "Pytest plugin for measuring coverage."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861"},
+    {file = "pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1"},
+]
+
+[package.dependencies]
+coverage = {version = ">=7.10.6", extras = ["toml"]}
+pluggy = ">=1.2"
+pytest = ">=7"
+
+[package.extras]
+testing = ["process-tests", "pytest-xdist", "virtualenv"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -1353,4 +1492,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12"
-content-hash = "2f9995976315c2c4d4e3ab01fa9c3c4784b369197a65729e132c117850dbc4d9"
+content-hash = "713ec899ca05bcd964c5a1c1c1c48564a0ab8ea40e8bcabf9cd41bf1ba17335b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ ruff = ">=0.14.8,<0.15.0"
 pre-commit = "^4.5.0"
 pytest = "^9.0.2"
 pytest-asyncio = "^1.3.0"
+pytest-cov = "^7.0.0"
 
 [tool.mypy]
 python_version = "3.10"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -504,3 +504,71 @@ def test_parse_telegraph_access_token_absent_is_none() -> None:
     app_cfg = config._parse_app_config(raw)
 
     assert app_cfg.telegraph.access_token is None
+
+
+# ---------------------------------------------------------------------------
+# _parse_bot – summary_hour / summary_minute range validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_hour", [-1, 24, 100])
+def test_parse_app_config_summary_hour_out_of_range_raises(bad_hour: int) -> None:
+    raw = _make_minimal_raw()
+    raw["bot"]["summary_hour"] = bad_hour
+
+    with pytest.raises(ValueError) as exc:
+        config._parse_app_config(raw)
+
+    assert "summary_hour" in str(exc.value)
+
+
+@pytest.mark.parametrize("bad_minute", [-1, 60, 100])
+def test_parse_app_config_summary_minute_out_of_range_raises(bad_minute: int) -> None:
+    raw = _make_minimal_raw()
+    raw["bot"]["summary_minute"] = bad_minute
+
+    with pytest.raises(ValueError) as exc:
+        config._parse_app_config(raw)
+
+    assert "summary_minute" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# _parse_llm – temperature range validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_temp", [-0.1, 2.1, 5.0])
+def test_parse_app_config_temperature_out_of_range_raises(bad_temp: float) -> None:
+    raw = _make_minimal_raw()
+    raw["llm"]["temperature"] = bad_temp
+
+    with pytest.raises(ValueError) as exc:
+        config._parse_app_config(raw)
+
+    assert "temperature" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# BotConfig.allowed_user_ids – invalid entry warning
+# ---------------------------------------------------------------------------
+
+
+def test_bot_config_allowed_user_ids_skips_invalid_entry_and_emits_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Non-integer, non-@ values in allowed_users must be skipped with a WARNING.
+
+    The cached_property computes lazily on first access; the warning should
+    appear at that point and the invalid token must not appear in the result.
+    """
+    raw = _make_minimal_raw()
+    raw["bot"]["allowed_users"] = "123,notanid,@admin"
+
+    app_cfg = config._parse_app_config(raw)
+
+    with caplog.at_level("WARNING", logger="teledigest"):
+        ids = app_cfg.bot.allowed_user_ids
+
+    assert ids == {123}
+    assert any("notanid" in r.message for r in caplog.records)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import sys
+import traceback
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
-from teledigest.main import parse_args
+import pytest
+
+from teledigest.main import _run, main, parse_args
 
 # ---------------------------------------------------------------------------
 # parse_args
@@ -57,3 +60,111 @@ def test_parse_args_combined_flags():
     assert args.auth is True
     assert args.debug is True
     assert args.config == Path("my.toml")
+
+
+# ---------------------------------------------------------------------------
+# main() – return codes and error handling
+# ---------------------------------------------------------------------------
+
+
+def test_main_returns_zero_on_success():
+    with (
+        patch("teledigest.main._run", new_callable=AsyncMock),
+        patch.object(sys, "argv", ["teledigest"]),
+    ):
+        assert main() == 0
+
+
+def test_main_returns_130_on_keyboard_interrupt():
+    with (
+        patch(
+            "teledigest.main._run",
+            new_callable=AsyncMock,
+            side_effect=KeyboardInterrupt,
+        ),
+        patch.object(sys, "argv", ["teledigest"]),
+    ):
+        assert main() == 130
+
+
+def test_main_returns_1_on_exception_and_prints_to_stderr(capsys):
+    with (
+        patch(
+            "teledigest.main._run",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("disk full"),
+        ),
+        patch.object(sys, "argv", ["teledigest"]),
+    ):
+        result = main()
+
+    assert result == 1
+    assert "disk full" in capsys.readouterr().err
+
+
+def test_main_with_debug_flag_calls_traceback_print_exc():
+    with (
+        patch(
+            "teledigest.main._run",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("oops"),
+        ),
+        patch("traceback.print_exc") as mock_tb,
+        patch.object(sys, "argv", ["teledigest", "--debug"]),
+    ):
+        result = main()
+
+    assert result == 1
+    mock_tb.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _run() – auth-only and normal execution paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_auth_only_skips_db_init_and_disconnects():
+    """`_run(auth_only=True)` must skip init_db and call disconnect_clients."""
+    with (
+        patch("teledigest.main.init_config"),
+        patch("teledigest.main.init_db") as mock_init_db,
+        patch("teledigest.main.create_clients", new_callable=AsyncMock),
+        patch("teledigest.main.start_clients", new_callable=AsyncMock) as mock_start,
+        patch(
+            "teledigest.main.disconnect_clients", new_callable=AsyncMock
+        ) as mock_disconnect,
+    ):
+        await _run(None, auth_only=True)
+
+    mock_init_db.assert_not_called()
+    mock_start.assert_awaited_once_with(auth_only=True)
+    mock_disconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_normal_mode_initialises_db_and_gathers_coroutines():
+    """`_run(auth_only=False)` must call init_db and pass both long-running
+    coroutines to asyncio.gather."""
+    gather_calls: list = []
+
+    async def fake_gather(*coros):
+        gather_calls.append(coros)
+        # Close any coroutines to suppress "never awaited" warnings.
+        for coro in coros:
+            if hasattr(coro, "close"):
+                coro.close()
+
+    with (
+        patch("teledigest.main.init_config"),
+        patch("teledigest.main.init_db") as mock_init_db,
+        patch("teledigest.main.create_clients", new_callable=AsyncMock),
+        patch("teledigest.main.start_clients", new_callable=AsyncMock),
+        patch("teledigest.main.run_clients", new_callable=AsyncMock),
+        patch("teledigest.main.summary_scheduler", new_callable=AsyncMock),
+        patch("asyncio.gather", new=fake_gather),
+    ):
+        await _run(None, auth_only=False)
+
+    mock_init_db.assert_called_once()
+    assert len(gather_calls) == 1

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,236 @@
+"""Tests for teledigest.scheduler — covers the digest scheduling loop.
+
+The scheduler is an infinite ``while True`` loop, so every test drives it
+by replacing ``asyncio.sleep`` with an async stub that raises ``_BreakLoop``
+after a configurable number of calls, then catches that sentinel exception.
+
+``datetime.datetime`` in the scheduler's own namespace is patched via
+``patch.object(sched, "dt")`` so that ``dt.datetime.now(tz)`` returns a
+fixed ``datetime`` object without touching the global ``datetime`` module.
+All dependent I/O functions (LLM, DB, Telegram, Telegraph) are patched to
+avoid real network calls.
+"""
+
+from __future__ import annotations
+
+import datetime as real_dt
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from teledigest import config as cfg
+from teledigest import scheduler as sched
+from teledigest.db import Message
+
+# ---------------------------------------------------------------------------
+# Sentinel used to break the infinite loop
+# ---------------------------------------------------------------------------
+
+
+class _BreakLoop(Exception):
+    """Raised by the fake asyncio.sleep to exit the scheduler loop."""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_app_config(
+    *,
+    summary_hour: int = 21,
+    summary_minute: int = 0,
+    summary_brief: bool = False,
+    time_zone: str = "UTC",
+    max_messages: int = 100,
+) -> cfg.AppConfig:
+    return cfg.AppConfig(
+        telegram=cfg.TelegramConfig(
+            api_id=1, api_hash="hash", bot_token="token", sessions_dir=Path("data")
+        ),
+        bot=cfg.BotConfig(
+            channels=["@c1"],
+            summary_target="@digest",
+            time_zone=time_zone,
+            summary_hour=summary_hour,
+            summary_minute=summary_minute,
+            summary_brief=summary_brief,
+        ),
+        llm=cfg.LLMConfig(
+            model="gpt-4.1",
+            api_key="sk-test",
+            system_prompt="",
+            user_prompt="",
+            max_messages=max_messages,
+        ),
+        storage=cfg.StorageConfig(rag_keywords=[], db_path=Path(":memory:")),
+        logging=cfg.LoggingConfig(level="WARNING"),
+    )
+
+
+@pytest.fixture
+def app_config(monkeypatch) -> cfg.AppConfig:
+    app_cfg = _make_app_config()
+    monkeypatch.setattr(cfg, "_CONFIG", app_cfg, raising=False)
+    return app_cfg
+
+
+def _fixed_now(hour: int = 21, minute: int = 0) -> real_dt.datetime:
+    """Return a UTC datetime that matches the default summary_hour:summary_minute."""
+    return real_dt.datetime(2024, 6, 1, hour, minute, 0, tzinfo=real_dt.timezone.utc)
+
+
+async def _drive(max_sleeps: int = 1) -> list[float]:
+    """Run the scheduler until *max_sleeps* asyncio.sleep calls have occurred.
+
+    Returns the list of sleep durations so callers can assert on them.
+    """
+    sleep_durations: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_durations.append(seconds)
+        if len(sleep_durations) >= max_sleeps:
+            raise _BreakLoop
+
+    with patch("asyncio.sleep", new=fake_sleep):
+        with pytest.raises(_BreakLoop):
+            await sched.summary_scheduler()
+
+    return sleep_durations
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_summary_scheduler_sends_digest_at_scheduled_time(app_config):
+    """When the clock matches summary_hour:summary_minute the scheduler must
+    call llm_summarize, then send_message_long with the result."""
+    messages = [Message(channel="@c1", text="latest war news")]
+    send_mock = AsyncMock()
+
+    with (
+        patch.object(sched, "dt") as mock_dt,
+        patch.object(sched, "get_relevant_messages_last_24h", return_value=messages),
+        patch.object(sched, "llm_summarize", return_value="AI Summary"),
+        patch.object(sched, "send_message_long", send_mock),
+        patch.object(sched, "get_bot_client", return_value=MagicMock()),
+    ):
+        mock_dt.datetime.now.return_value = _fixed_now(21, 0)
+        await _drive(max_sleeps=1)
+
+    send_mock.assert_awaited_once()
+    _bot_client, target, outgoing, *_ = send_mock.call_args[0]
+    assert target == "@digest"
+    assert "AI Summary" in outgoing
+
+
+@pytest.mark.asyncio
+async def test_summary_scheduler_deduplicates_same_day(app_config):
+    """A second trigger within the same calendar day must not call
+    send_message_long again; the deduplication sleep(60) fires instead."""
+    messages = [Message(channel="@c1", text="war update")]
+    send_mock = AsyncMock()
+
+    with (
+        patch.object(sched, "dt") as mock_dt,
+        patch.object(sched, "get_relevant_messages_last_24h", return_value=messages),
+        patch.object(sched, "llm_summarize", return_value="Summary"),
+        patch.object(sched, "send_message_long", send_mock),
+        patch.object(sched, "get_bot_client", return_value=MagicMock()),
+    ):
+        # Both iterations return the same time so today == last_run_for on the second pass.
+        mock_dt.datetime.now.return_value = _fixed_now(21, 0)
+        # First sleep(65) after sending + second sleep(60) from dedup guard = 2 sleeps.
+        sleep_durations = await _drive(max_sleeps=2)
+
+    # The digest is sent exactly once despite two trigger matches.
+    assert send_mock.await_count == 1
+    # The second sleep must be the short dedup pause.
+    assert sleep_durations == [65, 60]
+
+
+@pytest.mark.asyncio
+async def test_summary_scheduler_sends_notice_when_no_messages(app_config):
+    """When no messages are available the scheduler must send a human-readable
+    notice without calling llm_summarize."""
+    send_mock = AsyncMock()
+
+    with (
+        patch.object(sched, "dt") as mock_dt,
+        patch.object(sched, "get_relevant_messages_last_24h", return_value=[]),
+        patch.object(sched, "llm_summarize") as mock_llm,
+        patch.object(sched, "send_message_long", send_mock),
+        patch.object(sched, "get_bot_client", return_value=MagicMock()),
+    ):
+        mock_dt.datetime.now.return_value = _fixed_now(21, 0)
+        await _drive(max_sleeps=1)
+
+    mock_llm.assert_not_called()
+    send_mock.assert_awaited_once()
+    _bot, _target, outgoing, *_ = send_mock.call_args[0]
+    assert "no messages" in outgoing.lower()
+
+
+@pytest.mark.asyncio
+async def test_summary_scheduler_uses_brief_path_when_configured(monkeypatch):
+    """When summary_brief=True and messages exist, the scheduler must post to
+    Telegraph, call llm_summarize_brief, and send the combined output."""
+    app_cfg = _make_app_config(summary_brief=True)
+    monkeypatch.setattr(cfg, "_CONFIG", app_cfg, raising=False)
+
+    messages = [Message(channel="@c1", text="war news")]
+    send_mock = AsyncMock()
+
+    with (
+        patch.object(sched, "dt") as mock_dt,
+        patch.object(sched, "get_relevant_messages_last_24h", return_value=messages),
+        patch.object(sched, "llm_summarize", return_value="Full digest"),
+        patch.object(
+            sched,
+            "post_to_telegraph",
+            return_value="https://telegra.ph/test-01-01",
+        ),
+        patch.object(sched, "llm_summarize_brief", return_value="Brief!"),
+        patch.object(sched, "send_message_long", send_mock),
+        patch.object(sched, "get_bot_client", return_value=MagicMock()),
+    ):
+        mock_dt.datetime.now.return_value = _fixed_now(21, 0)
+        await _drive(max_sleeps=1)
+
+    send_mock.assert_awaited_once()
+    _bot, _target, outgoing, *_ = send_mock.call_args[0]
+    assert "Brief!" in outgoing
+    assert "telegra.ph" in outgoing
+
+
+@pytest.mark.asyncio
+async def test_summary_scheduler_handles_rpc_error_without_propagating(app_config):
+    """An RPCError raised by send_message_long must be caught and logged; the
+    scheduler must still update last_run_for and sleep normally afterwards."""
+
+    # Replace the module-level RPCError name with a plain exception so we can
+    # raise it without constructing a real Telethon RPC object.
+    class _FakeRPCError(Exception):
+        pass
+
+    messages = [Message(channel="@c1", text="news")]
+    send_mock = AsyncMock(side_effect=_FakeRPCError("timed out"))
+
+    with (
+        patch.object(sched, "dt") as mock_dt,
+        patch.object(sched, "RPCError", _FakeRPCError),
+        patch.object(sched, "get_relevant_messages_last_24h", return_value=messages),
+        patch.object(sched, "llm_summarize", return_value="Summary"),
+        patch.object(sched, "send_message_long", send_mock),
+        patch.object(sched, "get_bot_client", return_value=MagicMock()),
+    ):
+        mock_dt.datetime.now.return_value = _fixed_now(21, 0)
+        # sleep(65) still fires after the error — that is what we break on.
+        sleep_durations = await _drive(max_sleeps=1)
+
+    # The error was swallowed; the post-error sleep(65) still ran.
+    assert sleep_durations == [65]

--- a/tests/test_telegram_client.py
+++ b/tests/test_telegram_client.py
@@ -516,3 +516,174 @@ def test_get_bot_client_returns_initialized_client(monkeypatch):
     fake_client = MagicMock()
     monkeypatch.setattr(tc, "bot_client", fake_client)
     assert tc.get_bot_client() is fake_client
+
+
+# ---------------------------------------------------------------------------
+# auth_dialog_handler – WAIT_CODE step
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_dialog_handler_code_step_success(monkeypatch, app_config):
+    """Successful sign_in must set user_auth_state=OK and reply with a success message."""
+    app_config.bot.allowed_users_raw = ""
+    monkeypatch.setattr(tc, "user_auth_state", UserAuthState.REQUIRED)
+    dialogs: dict = {
+        456: AuthDialog(
+            step=AuthStep.WAIT_CODE, phone="+1234567890", phone_code_hash="h"
+        )
+    }
+    monkeypatch.setattr(tc, "auth_dialogs", dialogs)
+
+    fake_user_client = AsyncMock()
+    fake_user_client.sign_in = AsyncMock()
+    fake_user_client.get_me = AsyncMock()
+    monkeypatch.setattr(tc, "user_client", fake_user_client)
+    monkeypatch.setattr(tc, "ensure_joined_and_resolve_channels", AsyncMock())
+
+    event = _make_event(raw_text="1 2 3 4 5", chat_id=456)
+    await tc.auth_dialog_handler(event)
+
+    assert 456 not in dialogs
+    assert tc.user_auth_state == UserAuthState.OK
+    event.reply.assert_called_once()
+    assert "successful" in event.reply.call_args[0][0].lower()
+
+
+@pytest.mark.asyncio
+async def test_auth_dialog_handler_code_step_session_password_needed(
+    monkeypatch, app_config
+):
+    """SessionPasswordNeededError must clean up the dialog and inform the user."""
+    app_config.bot.allowed_users_raw = ""
+
+    # Patch the name in the tc module so the except clause catches our fake class.
+    class _FakeSPNError(Exception):
+        pass
+
+    monkeypatch.setattr(tc, "SessionPasswordNeededError", _FakeSPNError)
+
+    dialogs: dict = {
+        456: AuthDialog(
+            step=AuthStep.WAIT_CODE, phone="+1234567890", phone_code_hash="h"
+        )
+    }
+    monkeypatch.setattr(tc, "auth_dialogs", dialogs)
+
+    fake_user_client = AsyncMock()
+    fake_user_client.sign_in = AsyncMock(side_effect=_FakeSPNError())
+    monkeypatch.setattr(tc, "user_client", fake_user_client)
+
+    event = _make_event(raw_text="1 2 3 4 5", chat_id=456)
+    await tc.auth_dialog_handler(event)
+
+    assert 456 not in dialogs
+    event.reply.assert_called_once()
+    reply_text = event.reply.call_args[0][0]
+    assert "password" in reply_text.lower() or "2fa" in reply_text.lower()
+
+
+@pytest.mark.asyncio
+async def test_auth_dialog_handler_code_step_general_error(monkeypatch, app_config):
+    """A generic exception during sign_in must clean up the dialog and report the error."""
+    app_config.bot.allowed_users_raw = ""
+    dialogs: dict = {
+        456: AuthDialog(
+            step=AuthStep.WAIT_CODE, phone="+1234567890", phone_code_hash="h"
+        )
+    }
+    monkeypatch.setattr(tc, "auth_dialogs", dialogs)
+
+    fake_user_client = AsyncMock()
+    fake_user_client.sign_in = AsyncMock(side_effect=Exception("bad code"))
+    monkeypatch.setattr(tc, "user_client", fake_user_client)
+
+    event = _make_event(raw_text="1 2 3 4 5", chat_id=456)
+    await tc.auth_dialog_handler(event)
+
+    assert 456 not in dialogs
+    event.reply.assert_called_once()
+    assert "failed" in event.reply.call_args[0][0].lower()
+
+
+@pytest.mark.asyncio
+async def test_auth_dialog_handler_denied_when_user_not_allowed_in_active_dialog(
+    monkeypatch, app_config
+):
+    """Permission check fires even when a dialog is active; denied users get a rejection."""
+    app_config.bot.allowed_users_raw = "999"  # only user 999 allowed
+    dialogs: dict = {456: AuthDialog(step=AuthStep.WAIT_PHONE)}
+    monkeypatch.setattr(tc, "auth_dialogs", dialogs)
+
+    event = _make_event(raw_text="+1234567890", chat_id=456, sender_id=123)
+    await tc.auth_dialog_handler(event)
+
+    event.reply.assert_called_once()
+    assert "not allowed" in event.reply.call_args[0][0]
+
+
+# ---------------------------------------------------------------------------
+# today_command – summary_brief path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_today_command_with_summary_brief_posts_to_telegraph(
+    monkeypatch, app_config
+):
+    """When summary_brief=True, today_command must call post_to_telegraph and
+    llm_summarize_brief, then send a message containing the brief text and the
+    Telegraph URL."""
+    app_config.bot.allowed_users_raw = ""
+    app_config.bot.summary_brief = True
+    event = _make_event()
+
+    messages = [Message(channel="@c1", text="war update")]
+    monkeypatch.setattr(
+        tc, "get_relevant_messages_last_24h", lambda max_docs=200: messages
+    )
+    monkeypatch.setattr(tc, "llm_summarize", lambda day, msgs: "Full digest")
+    monkeypatch.setattr(
+        tc, "post_to_telegraph", lambda title, html: "https://telegra.ph/test-01-01"
+    )
+    monkeypatch.setattr(tc, "llm_summarize_brief", lambda day, digest: "Brief!")
+
+    reply_long_mock = AsyncMock()
+    monkeypatch.setattr(tc, "reply_long", reply_long_mock)
+
+    await tc.today_command(event)
+
+    reply_long_mock.assert_called_once()
+    outgoing = reply_long_mock.call_args[0][1]
+    assert "Brief!" in outgoing
+    assert "telegra.ph" in outgoing
+
+
+# ---------------------------------------------------------------------------
+# status_command – prompt_chars line
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_status_command_includes_prompt_chars_when_relevant_messages_present(
+    monkeypatch, app_config
+):
+    """When relevant messages exist the status reply must include a 'prompt size' line."""
+    app_config.bot.allowed_users_raw = ""
+    event = _make_event()
+
+    relevant = [Message(channel="@c1", text="war news")]
+    monkeypatch.setattr(
+        tc, "get_relevant_messages_last_24h", lambda max_docs=200: relevant
+    )
+    monkeypatch.setattr(tc, "get_messages_last_24h", lambda: relevant)
+    # build_prompt returns a known user-prompt so we can predict prompt_chars
+    monkeypatch.setattr(tc, "build_prompt", lambda day, msgs: ("sys", "user-content"))
+
+    reply_long_mock = AsyncMock()
+    monkeypatch.setattr(tc, "reply_long", reply_long_mock)
+
+    await tc.status_command(event)
+
+    reply_text = reply_long_mock.call_args[0][1]
+    assert "<b>Current prompt size:</b> <code>12</code> chars" in reply_text

--- a/tests/test_text_sanitize.py
+++ b/tests/test_text_sanitize.py
@@ -49,3 +49,16 @@ def test_strip_markdown_fence_missing_closing_fence() -> None:
     # and only strips the last line if it is exactly ```
     raw = "```\nHello\nWorld\n"
     assert ts.strip_markdown_fence(raw) == "Hello\nWorld"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_text_empty_string_returns_empty() -> None:
+    assert ts.sanitize_text("") == ""
+
+
+def test_strip_markdown_fence_empty_string_returns_original() -> None:
+    assert ts.strip_markdown_fence("") == ""


### PR DESCRIPTION

Increases overall test coverage from ~60% to 91% (752/828 statements) by adding targeted tests across five modules that were previously untested or only partially covered.

```
Name                                Stmts   Miss  Cover   Missing
-----------------------------------------------------------------
src/teledigest/__init__.py              1      0   100%
src/teledigest/config.py              157      0   100%
src/teledigest/db.py                  109     12    89%   98-100, 147-154, 196-198, 281
src/teledigest/llm.py                  62      0   100%
src/teledigest/main.py                 39      0   100%
src/teledigest/message_utils.py        51      0   100%
src/teledigest/scheduler.py            45      2    96%   39, 84
src/teledigest/telegram_client.py     232     62    73%   283, 300-330, 350-380, 410-437, 443-449, 457-464
src/teledigest/telegraph.py            93      0   100%
src/teledigest/text_sanitize.py        39      0   100%
-----------------------------------------------------------------
TOTAL                                 828     76    91%
196 passed in 2.51s
```